### PR TITLE
Preserve source map key order for torrent files

### DIFF
--- a/src/main/java/com/dampcake/bencode/BencodeInputStream.java
+++ b/src/main/java/com/dampcake/bencode/BencodeInputStream.java
@@ -23,9 +23,9 @@ import java.io.InvalidObjectException;
 import java.io.PushbackInputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * InputStream for reading bencoded data.
@@ -190,7 +190,7 @@ public class BencodeInputStream extends FilterInputStream {
         int token = in.read();
         validateToken(token, Type.DICTIONARY);
 
-        Map<String, Object> map = new TreeMap<String, Object>();
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
         while ((token = in.read()) != Bencode.TERMINATOR) {
             checkEOF(token);
 

--- a/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
+++ b/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * OutputStream for writing bencoded data.
@@ -157,14 +155,8 @@ public class BencodeOutputStream extends FilterOutputStream {
         return buffer.toString();
     }
 
-    private static String encode(final Map<?, ?> m) {
-        if (m == null) throw new NullPointerException("m cannot be null");
-
-        Map<?, ?> map;
-        if (!(m instanceof SortedMap<?, ?>))
-            map = new TreeMap<Object, Object>(m);
-        else
-            map = m;
+    private static String encode(final Map<?, ?> map) {
+        if (map == null) throw new NullPointerException("m cannot be null");
 
         StringBuilder buffer = new StringBuilder();
         buffer.append(Bencode.DICTIONARY);

--- a/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
+++ b/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
@@ -156,7 +156,7 @@ public class BencodeOutputStream extends FilterOutputStream {
     }
 
     private static String encode(final Map<?, ?> map) {
-        if (map == null) throw new NullPointerException("m cannot be null");
+        if (map == null) throw new NullPointerException("map cannot be null");
 
         StringBuilder buffer = new StringBuilder();
         buffer.append(Bencode.DICTIONARY);

--- a/src/test/java/com/dampcake/bencode/BencodeOutputStreamTest.java
+++ b/src/test/java/com/dampcake/bencode/BencodeOutputStreamTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 import static com.dampcake.bencode.Assert.assertThrows;
@@ -140,7 +141,7 @@ public class BencodeOutputStreamTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testWriteDictionary() throws Exception {
-        instance.writeDictionary(new HashMap<Object, Object>() {{
+        instance.writeDictionary(new TreeMap<Object, Object>() {{
             put("string", "value");
             put("number", 123456);
             put("list", new ArrayList<Object>() {{
@@ -168,7 +169,7 @@ public class BencodeOutputStreamTest {
     public void testWriteDictionaryKeyCastException() throws Exception {
         assertThrows(ClassCastException.class, new Runnable() {
             public void run() throws Exception {
-                instance.writeDictionary(new HashMap<Object, Object>() {{
+                instance.writeDictionary(new TreeMap<Object, Object>() {{
                     put("string", "value");
                     put(123, "number-key");
                 }});

--- a/src/test/java/com/dampcake/bencode/BencodeOutputStreamTest.java
+++ b/src/test/java/com/dampcake/bencode/BencodeOutputStreamTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
@@ -141,7 +142,7 @@ public class BencodeOutputStreamTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testWriteDictionary() throws Exception {
-        instance.writeDictionary(new TreeMap<Object, Object>() {{
+        instance.writeDictionary(new LinkedHashMap<Object, Object>() {{
             put("string", "value");
             put("number", 123456);
             put("list", new ArrayList<Object>() {{
@@ -154,7 +155,7 @@ public class BencodeOutputStreamTest {
             }});
         }});
 
-        assertEquals("d4:dictd3:1234:test3:4565:thinge4:listl11:list-item-111:list-item-2e6:numberi123456e6:string5:valuee",
+        assertEquals("d6:string5:value6:numberi123456e4:listl11:list-item-111:list-item-2e4:dictd3:1234:test3:4565:thingee",
                 new String(out.toByteArray(), instance.getCharset()));
     }
 

--- a/src/test/java/com/dampcake/bencode/BencodeTest.java
+++ b/src/test/java/com/dampcake/bencode/BencodeTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 import static org.hamcrest.core.IsInstanceOf.any;
@@ -346,7 +347,7 @@ public class BencodeTest {
 
     @Test
     public void testWriteDictionary() throws Exception {
-        byte[] encoded = instance.encode(new HashMap<Object, Object>() {{
+        byte[] encoded = instance.encode(new TreeMap<Object, Object>() {{
             put("string", "value");
             put("number", 123456);
             put("list", new ArrayList<Object>() {{
@@ -372,10 +373,9 @@ public class BencodeTest {
 
     @Test
     public void testWriteDictionaryKeyCastException() throws Exception {
-        exception.expect(BencodeException.class);
-        exception.expectCause(any(ClassCastException.class));
+        exception.expect(any(ClassCastException.class));
 
-        instance.encode(new HashMap<Object, Object>() {{
+        instance.encode(new TreeMap<Object, Object>() {{
             put("string", "value");
             put(123, "number-key");
         }});

--- a/src/test/java/com/dampcake/bencode/BencodeTest.java
+++ b/src/test/java/com/dampcake/bencode/BencodeTest.java
@@ -10,6 +10,7 @@ import java.io.InvalidObjectException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -347,7 +348,7 @@ public class BencodeTest {
 
     @Test
     public void testWriteDictionary() throws Exception {
-        byte[] encoded = instance.encode(new TreeMap<Object, Object>() {{
+        byte[] encoded = instance.encode(new LinkedHashMap<Object, Object>() {{
             put("string", "value");
             put("number", 123456);
             put("list", new ArrayList<Object>() {{
@@ -360,7 +361,7 @@ public class BencodeTest {
             }});
         }});
 
-        assertEquals("d4:dictd3:1234:test3:4565:thinge4:listl11:list-item-111:list-item-2e6:numberi123456e6:string5:valuee",
+        assertEquals("d6:string5:value6:numberi123456e4:listl11:list-item-111:list-item-2e4:dictd3:1234:test3:4565:thingee",
                 new String(encoded, instance.getCharset()));
     }
 


### PR DESCRIPTION
Simple change to keep the source order of keys in maps. Useful for

- Reading and writing a bencoded file gives identical output
- Issue #5: Allows torrent infohashes to be properly generated 
