### PR TITLE
Dictionaries keys must be appear in sorted order (required by bencode spec)

### DIFF
--- a/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
+++ b/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
@@ -22,6 +22,8 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * OutputStream for writing bencoded data.
@@ -184,8 +186,14 @@ public class BencodeOutputStream extends FilterOutputStream {
         return buffer.toByteArray();
     }
 
-    private byte[] encode(final Map<?, ?> map) throws IOException {
-        if (map == null) throw new NullPointerException("map cannot be null");
+    private byte[] encode(final Map<?, ?> m) throws IOException {
+        if (m == null) throw new NullPointerException("m cannot be null");
+
+        Map<?, ?> map;
+        if (!(m instanceof SortedMap<?, ?>))
+            map = new TreeMap<>(m);
+        else
+            map = m;
 
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         buffer.write(Bencode.DICTIONARY);

--- a/src/test/java/com/dampcake/bencode/BencodeOutputStreamTest.java
+++ b/src/test/java/com/dampcake/bencode/BencodeOutputStreamTest.java
@@ -181,7 +181,7 @@ public class BencodeOutputStreamTest {
             }});
         }});
 
-        assertEquals("d6:string5:value6:numberi123456e4:listl11:list-item-111:list-item-2e4:dictd3:1234:test3:4565:thingee",
+        assertEquals("d4:dictd3:1234:test3:4565:thinge4:listl11:list-item-111:list-item-2e6:numberi123456e6:string5:valuee",
                 new String(out.toByteArray(), instance.getCharset()));
     }
 

--- a/src/test/java/com/dampcake/bencode/BencodeTest.java
+++ b/src/test/java/com/dampcake/bencode/BencodeTest.java
@@ -415,7 +415,7 @@ public class BencodeTest {
             }});
         }});
 
-        assertEquals("d6:string5:value6:numberi123456e4:listl11:list-item-111:list-item-2e4:dictd3:1234:test3:4565:thingee",
+        assertEquals("d4:dictd3:1234:test3:4565:thinge4:listl11:list-item-111:list-item-2e6:numberi123456e6:string5:valuee",
                 new String(encoded, instance.getCharset()));
     }
 


### PR DESCRIPTION
The default comparator may give the wrong order (because it is not a simple "binary comparison"), but it will work for most cases.
Otherwise, it is possible to use TreeMap with a custom binary comparator.