### PR TITLE
Properly encode multibyte codepoints

### DIFF
--- a/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
+++ b/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
@@ -144,9 +144,10 @@ public class BencodeOutputStream extends FilterOutputStream {
         if (s == null) throw new NullPointerException("s cannot be null");
 
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        buffer.write(Integer.toString(s.length()).getBytes(charset));
+        byte[] bytes = s.getBytes(charset);
+        buffer.write(Integer.toString(bytes.length).getBytes(charset));
         buffer.write(Bencode.SEPARATOR);
-        buffer.write(s.getBytes(charset));
+        buffer.write(bytes);
 
         return buffer.toByteArray();
     }

--- a/src/test/java/com/dampcake/bencode/BencodeTest.java
+++ b/src/test/java/com/dampcake/bencode/BencodeTest.java
@@ -128,6 +128,13 @@ public class BencodeTest {
     }
 
     @Test
+    public void testDecodeStringMultiByteCodePoints() {
+        String decoded = instance.decode("7:Garçon".getBytes(), Type.STRING);
+
+        assertEquals("Garçon", decoded);
+    }
+
+    @Test
     public void testDecodeEmptyString() {
         String decoded = instance.decode("0:123".getBytes(), Type.STRING);
 
@@ -319,6 +326,12 @@ public class BencodeTest {
         assertEquals("12:Hello World!", new String(encoded, instance.getCharset()));
     }
 
+    @Test
+    public void testWriteStringMultiByteCodePoints() throws Exception {
+        byte[] encoded = instance.encode("Garçon");
+
+        assertEquals("7:Garçon", new String(encoded, instance.getCharset()));
+    }
     @Test
     public void testWriteStringEmpty() throws Exception {
         byte[] encoded = instance.encode("");


### PR DESCRIPTION
The length of the string encoding is not properly computed as the required value is the number of bytes rather than the number of code-points.