### PR TITLE
Support encoding of byte arrays

### DIFF
--- a/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
+++ b/src/main/java/com/dampcake/bencode/BencodeOutputStream.java
@@ -94,6 +94,20 @@ public class BencodeOutputStream extends FilterOutputStream {
     }
 
     /**
+     * Writes the passed byte[] to the stream.
+     *
+     * @param array the byte[] to write to the stream
+     *
+     * @throws NullPointerException if the byte[] is null
+     * @throws IOException          if the underlying stream throws
+     *
+     * @since 1.4.1
+     */
+    public void writeString(final byte[] array) throws IOException {
+        write(encode(array));
+    }
+
+    /**
      * Writes the passed {@link Number} to the stream.
      * <p>
      * The number is converted to a {@link Long}, meaning any precision is lost as it not supported by the bencode spec.
@@ -218,6 +232,8 @@ public class BencodeOutputStream extends FilterOutputStream {
             return encode((Map<?, ?>) o);
         if (o instanceof ByteBuffer)
             return encode(((ByteBuffer) o).array());
+        if (o instanceof byte[])
+            return encode((byte[]) o);
 
         return encode(o.toString());
     }

--- a/src/test/java/com/dampcake/bencode/BencodeOutputStreamTest.java
+++ b/src/test/java/com/dampcake/bencode/BencodeOutputStreamTest.java
@@ -66,15 +66,29 @@ public class BencodeOutputStreamTest {
     }
 
     @Test
-    public void testWriteStringByteArray() throws Exception {
+    public void testWriteStringByteBuffer() throws Exception {
         instance.writeString(ByteBuffer.wrap("Hello World!".getBytes()));
 
         assertEquals("12:Hello World!", new String(out.toByteArray(), instance.getCharset()));
     }
 
     @Test
-    public void testWriteStringEmptyByteArray() throws Exception {
+    public void testWriteStringEmptyByteBuffer() throws Exception {
         instance.writeString(ByteBuffer.wrap(new byte[0]));
+
+        assertEquals("0:", new String(out.toByteArray(), instance.getCharset()));
+    }
+
+    @Test
+    public void testWriteStringByteArray() throws Exception {
+        instance.writeString("Hello World!".getBytes());
+
+        assertEquals("12:Hello World!", new String(out.toByteArray(), instance.getCharset()));
+    }
+
+    @Test
+    public void testWriteStringEmptyByteArray() throws Exception {
+        instance.writeString(new byte[0]);
 
         assertEquals("0:", new String(out.toByteArray(), instance.getCharset()));
     }
@@ -124,9 +138,10 @@ public class BencodeOutputStreamTest {
                 add(123);
                 add(456);
             }});
+            add("Foo".getBytes());
         }});
 
-        assertEquals("l5:Hello6:World!li123ei456eee", new String(out.toByteArray(), instance.getCharset()));
+        assertEquals("l5:Hello6:World!li123ei456ee3:Fooe", new String(out.toByteArray(), instance.getCharset()));
     }
 
     @Test


### PR DESCRIPTION
When serializing a byte[] value, it would call byte[].toString() rather than writing out the bytes in the array. This patch will check if a value is a byte[] and handle it accordingly.