### PR TITLE
Bump GHA actions and target supported java versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        java: [ 8, 11, 17, 21, 23, 24 ]
     env:
       JAVA: ${{ matrix.java }}
     name: Java ${{ matrix.java }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
     - name: Test
       run: mvn -B test jacoco:report
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v5
       with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
         env_vars: JAVA
   deploy:
     runs-on: ubuntu-latest
@@ -33,9 +35,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     name: Deploy
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: 8


### PR DESCRIPTION
- Bumps GHA actions to latest available
- Limits Java versions tested against to supported versions (LTS + latest)
- Update codecov to use token & fail on error