### PR TITLE
Remove redundant check from readObject condition

### DIFF
--- a/src/main/java/com/dampcake/bencode/BencodeInputStream.java
+++ b/src/main/java/com/dampcake/bencode/BencodeInputStream.java
@@ -256,7 +256,7 @@ public class BencodeInputStream extends FilterInputStream {
 
         if (type == Type.STRING && !useBytes)
             return readString();
-        if (type == Type.STRING && useBytes)
+        if (type == Type.STRING)
             return readStringBytes();
         if (type == Type.NUMBER)
             return readNumber();


### PR DESCRIPTION
This check is redundant because of we already know `useBytes` is not false from the check above if type is a String.